### PR TITLE
typescript-node:18-bookworm を利用

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/devcontainers/typescript-node:14-bullseye
+FROM mcr.microsoft.com/devcontainers/typescript-node:18-bookworm
 
 RUN apt-get update && apt-get -y upgrade \
     && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install bash-completion \
-    && npm install -g npm@9.8.1 \
+    && /usr/bin/sudo -u node sh -c "npm install -g npm@9.8.1" \
     && rm /etc/localtime \
     && ln -s /usr/share/zoneinfo/Asia/Tokyo /etc/localtime \
     && mkdir -p /home/node/workspace /home/node/.vscode-server/extensions \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,11 +2,11 @@
   "name": "devcon-node-dod-git",
   "dockerFile": "./Dockerfile",  
   "features": {
-    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
-      "version": "20.10",
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1.3.1": {
+      "version": "latest",
       "dockerDashComposeVersion": "v2"
     },
-    "ghcr.io/devcontainers/features/git:1": { "version": "latest" },
-    "ghcr.io/devcontainers/features/git-lfs:1": {}
+    "ghcr.io/devcontainers/features/git:1.1.6": { "version": "latest" },
+    "ghcr.io/devcontainers/features/git-lfs:1.1.1": { "version": "latest" }
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # devcon-node-dod-git
 
-これは、mcr.microsoft.com/devcontainers/typescript-node:14-bullseye の Dev Container をベースとして、下記 features を追加したイメージ devcon-node-dod-git をビルドするためのリポジトリです。
+これは、[mcr.microsoft.com/devcontainers（0.3.26）の typescript-node:18-bookworm](https://github.com/devcontainers/images/tree/v0.3.26/src/typescript-node) の Dev Container をベースとして、下記 features を追加したイメージ devcon-node-dod-git をビルドするためのリポジトリです。
 
 - ghcr.io/devcontainers/features/docker-outside-of-docker
 - ghcr.io/devcontainers/features/git
@@ -10,8 +10,24 @@ node ユーザーを使うことを想定していて、Docker ボリューム�
 
 - bash-completion
 
-実行するには、Linux で実行可能な Node.js の環境が必要です。下記のようにコマンドを実行することで devcon-node-dod-git:1.0 の Docker イメージを作成することができます。
+実行するには、Linux で実行可能な Node.js の環境が必要です。下記のようにコマンドを実行することで devcon-node-dod-git:1.18 の Docker イメージを作成することができます。
 
 ```console
 sh build.sh
+```
+
+## ディレクトリ構成について
+
+ディレクトリ構成は次のようになっています。
+
+```text
+./
+├── .devcontainer/ ... 開発コンテナのビルド用ファイル
+│   ├── Dockerfile
+│   └── devcontainer.json
+├── LICENSE ... ライセンス
+├── README.md ... このファイル
+├── build.sh ... ビルド用スクリプト
+└── dev/ ... 開発時に使用するものを管理するためのディレクトリ
+    └── docker-compose.yml
 ```

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
-IMAGE_NAME=devcon-node-dod-git:1.0
+IMAGE_NAME=devcon-node-dod-git:1.18
 BUILD_DEVCON_DIR=$(cd $(dirname $0);pwd)
 PATH=${PATH}:${NPM_CONFIG_PREFIX}/bin
 

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,0 +1,7 @@
+name: devcon-node-dod-git
+services:
+  devcon-node-dod-git-dev:
+    image: mcr.microsoft.com/devcontainers/typescript-node:18-bookworm
+    container_name: devcon-node-dod-git-dev
+    hostname: devcon-node-dod-git-dev
+    tty: true


### PR DESCRIPTION
mcr.microsoft.com/devcontainers（0.3.26）の typescript-node:18-bookwormを使うようにアップデート